### PR TITLE
Fix invisible entry-date

### DIFF
--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -30,10 +30,6 @@ body {
 	}
 }
 
-.entry-date {
-	color: $white;
-}
-
 ///sections
 
 .content-header-title {


### PR DESCRIPTION
Entry date of updated posts was not visible as text colour was set to the same colour as the background.

![screenshot](http://snag.gy/Ueshz.jpg)