### PR TITLE
Add bookmark tags and properties for Going to the exact location of b…

### DIFF
--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -185,6 +185,13 @@ header .entry-meta {
 .year-heading {
 	margin-top: 0;
 }
+// Go to the exact location of bookmarks in tags, categories
+.anchor-bookmark{
+  display: block;
+  height: $menu-height; /*same height as header*/
+  margin-top: -$menu-height; /*same height as header*/
+  visibility: hidden;
+}
 // Permalink icon for link post
 .permalink {
 	margin-right: 7px;

--- a/categories/index.html
+++ b/categories/index.html
@@ -17,8 +17,9 @@ comments: false
 
 {% for item in (0..site.categories.size) %}{% unless forloop.last %}
   {% capture this_word %}{{ cats_list[item] | strip_newlines }}{% endcapture %}
+  <span class="anchor-bookmark" id="{{ this_word }}"></span>
 	<article>
-	<h2 id="{{ this_word }}" class="tag-heading">{{ this_word }}</h2>
+	<h2 class="tag-heading">{{ this_word }}</h2>
 		<ul>
     {% for post in site.categories[this_word] %}{% if post.title != null %}
       <li class="entry-title"><a href="{{ site.url }}{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></li>

--- a/tags/index.html
+++ b/tags/index.html
@@ -17,8 +17,9 @@ comments: false
 
 {% for item in (0..site.tags.size) %}{% unless forloop.last %}
   {% capture this_word %}{{ tags_list[item] | strip_newlines }}{% endcapture %}
+  <span class="anchor-bookmark" id="{{ this_word }}"></span>
 	<article>
-	<h2 id="{{ this_word }}" class="tag-heading">{{ this_word }}</h2>
+	<h2 class="tag-heading">{{ this_word }}</h2>
 		<ul>
     {% for post in site.tags[this_word] %}{% if post.title != null %}
       <li class="entry-title"><a href="{{ site.url }}{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></li>


### PR DESCRIPTION
**issue**

When a reader click a bookmark of tag or category, go to the other location. because it's **ANCHOR LINKS WITH A FIXED HEADER**.

1) click "code"

![pr1](https://cloud.githubusercontent.com/assets/7572251/14451138/8cba0660-00bf-11e6-89a2-5cdaeb3ef1f0.png)

2) go to other location (highlighting)
![p2](https://cloud.githubusercontent.com/assets/7572251/14451216/31a834d0-00c0-11e6-88e4-c8ed5e0dc190.png)

3) after apply this commit, go to exact location
![pr3](https://cloud.githubusercontent.com/assets/7572251/14451223/409aa7ca-00c0-11e6-8185-81e3900c4423.png)


I solved this problem by adding bookmark tags and properties for Going to the exact location of bookmarks in tags, categories.