### PR TITLE
Fix a problem of not moving to external link.

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -93,7 +93,11 @@
           </ul>
         </li>
       {% else %}
-        <li><a href="{{site.url}}{{menu.url}}"><h3>{{ menu.title }}</h3></a></li>
+        {% if menu.url contains 'http://' or menu.url contains 'https://' %}
+          <li><a href="{{menu.url}}" target="_blank"><h3>{{ menu.title }}</h3></a></li>
+        {% else %}
+          <li><a href="{{site.url}}{{menu.url}}"><h3>{{ menu.title }}</h3></a></li>
+        {% endif %}
       {% endif %}
     {% endfor %}
   </ul>


### PR DESCRIPTION
When clicked a link in nav tag, It went to the internal link which is properly not resolved.
It's solved by adding a condition of whether a link contains 'http or https'.