### PR TITLE
Fix: Absolute links in mobile menu

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -85,15 +85,27 @@
           </ul>
         </li>
       {% elsif menu.submenu %}
-        <li><a href="{{site.url}}{{menu.url}}"><h3>{{ menu.title }}</h3></a>
+        {% if menu.url contains 'http://' or menu.url contains 'https://' %}
+            <li><a href="{{menu.url}}"><h3>{{ menu.title }}</h3></a>
+        {% else %}
+            <li><a href="{{site.url}}{{menu.url}}"><h3>{{ menu.title }}</h3></a>
+        {% endif %}
           <ul>
             {% for sub in menu.submenu %}
-              <li><a href="{{site.url}}{{sub.url}}">{{sub.title}}</a></li>
+              {% if sub.url contains 'http://' or sub.url contains 'https://' %}
+                  <li><a href="{{sub.url}}">{{sub.title}}</a></li>
+              {% else %}
+                  <li><a href="{{site.url}}{{sub.url}}">{{sub.title}}</a></li>
+              {% endif %}
             {% endfor %}
           </ul>
         </li>
       {% else %}
-        <li><a href="{{site.url}}{{menu.url}}"><h3>{{ menu.title }}</h3></a></li>
+        {% if menu.url contains 'http://' or menu.url contains 'https://' %}
+            <li><a href="{{menu.url}}"><h3>{{ menu.title }}</h3></a></li>
+        {% else %}
+            <li><a href="{{site.url}}{{menu.url}}"><h3>{{ menu.title }}</h3></a></li>
+        {% endif %}
       {% endif %}
     {% endfor %}
   </ul>


### PR DESCRIPTION
This change fixes absolute menu entries in the mobile view of the page.
Before, when one put an absolute entry into the menu, the mobile view
would have a link to "SITE_URL/ENTRY_URL", which is invalid in case of
ab absolute entry URL.